### PR TITLE
Bloquer les conseillers qui n'ont pas activé leur compte

### DIFF
--- a/src/components/anonymous/Login.js
+++ b/src/components/anonymous/Login.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Fragment } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import Footer from '../Footer';
@@ -99,7 +99,18 @@ function Login() {
               <br/>{loggingIn && <span style={{ color: 'black' }}>Connexion en cours...</span>}
             </div>
             <div>
-              {error && <span className="invalid">{error.error}</span>}
+              {error && <span className="invalid">{
+                error.errorActivation === true ?
+                  <Fragment>
+                    <a
+                      href={process.env.REACT_APP_AIDE_URL + `/article/quand-vais-je-recevoir-mon-acces-a-lespace-coop-1acxbw6/`}
+                      target="blank"
+                      rel="noopener noreferrer">
+                        Merci d&rsquo;activer votre compte coop <span className="fr-fi-external-link-line fr-link--icon"></span>
+                    </a>
+                  </Fragment> :
+                  error.error
+              }</span>}
             </div>
             { role !== 'admin' &&
               <div className="mot-de-passe-oublie">

--- a/src/components/connected/cra/Components/SelectCP.js
+++ b/src/components/connected/cra/Components/SelectCP.js
@@ -63,13 +63,13 @@ function SelectCP({ voirInformation }) {
   const onClickButton = () => {
     dispatch(craActions.getSearchlist());
     setTimeout(() => {
-      document.getElementById('searchCP').focus();
+      document.getElementById('searchCP')?.focus();
     }, 100);
   };
 
   //Focus input
   const focusInput = () => {
-    document.getElementById('searchCP').focus();
+    document.getElementById('searchCP')?.focus();
   };
 
   return (

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -75,6 +75,10 @@ function handleResponse(response) {
       logout();
       return Promise.reject({ error: 'Identifiants incorrects' });
     }
+    if (roles.includes('conseiller') && !data.user?.name?.includes('conseiller-numerique.fr') && data.user?.passwordCreated === false) {
+      logout();
+      return Promise.reject({ error: `Merci d'activer votre compte coop !` });
+    }
     return data;
   });
 }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -77,7 +77,7 @@ function handleResponse(response) {
     }
     if (data.user?.passwordCreated === false) {
       logout();
-      return Promise.reject({ error: `Merci d'activer votre compte coop !` });
+      return Promise.reject({ errorActivation: true });
     }
     return data;
   });

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -75,7 +75,7 @@ function handleResponse(response) {
       logout();
       return Promise.reject({ error: 'Identifiants incorrects' });
     }
-    if (roles.includes('conseiller') && !data.user?.name?.includes('conseiller-numerique.fr') && data.user?.passwordCreated === false) {
+    if (data.user?.passwordCreated === false) {
       logout();
       return Promise.reject({ error: `Merci d'activer votre compte coop !` });
     }


### PR DESCRIPTION
- Concerne 5 conseillers qui se connectent à l'espace coop avec leur email perso (il y a eu des corrections pour que cela n'arrive plus dans mot de passe oublié et dans l'import coop - ce doit être des reliquats)
- En support : renvoyer les mails d'activation pour ces 5 comptes avec nouveau token